### PR TITLE
use versioncmp

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -32,11 +32,13 @@ class couchdb::base {
   # and it needs the ruby-dev package installed to build
   #include ruby::devel
 
-  case $::operatingsystemmajrelease {
-    '7':    { $couchrest_version = '1.2'}
-    default:{ $couchrest_version = 'latest'}
+  if versioncmp($::operatingsystemrelease, '8') < 0 {
+    $couchrest_version = '1.2'
   }
-
+  else {
+    $couchrest_version = 'latest'
+  }
+  
   ensure_packages('ruby-dev')
   ensure_packages('couchrest', {
     provider => 'gem',

--- a/spec/classes/couchdb_spec.rb
+++ b/spec/classes/couchdb_spec.rb
@@ -5,7 +5,7 @@ describe 'couchdb' do
     let(:params) { {:admin_pw => 'foo'} }
     let(:facts) do
       {
-      :operatingsystemmajrelease => '7',
+      :operatingsystemrelease => '7',
       :operatingsystem           => 'Debian',
       :lsbdistcodename           => 'wheezy',
       }
@@ -20,7 +20,7 @@ describe 'couchdb' do
     let(:params) { {:admin_pw => 'foo'} }
     let(:facts) do
       {
-      :operatingsystemmajrelease => '8',
+      :operatingsystemrelease => '8',
       :operatingsystem           => 'Debian',
       :lsbdistcodename           => 'jessie',
       }


### PR DESCRIPTION
I had a look at leap_cli if we could install facter backports before puppet runs.
I think this might be the easier/better way.
Feel free to close this pr if you disagree.
